### PR TITLE
Cleaner code for checking meta.json in custom widget zip

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -223,7 +223,7 @@ pub async fn install_custom_widget(
 	let new_widget_id = generate_widget_id();
 	let source_path = Path::new(zip_path);
 
-	let archive = match file::unzip(source_path) {
+	let mut archive = match file::unzip(source_path) {
 		Ok(archive) => archive,
 		Err(error) => {
 			return Err(format!("Failed to open zip: {}", error));
@@ -231,12 +231,11 @@ pub async fn install_custom_widget(
 	};
 
 	// check if zip contains meta.json
-	let has_meta =
-	    archive.by_name("config/meta.json").is_ok()
-	    || archive.by_name("config\\meta.json").is_ok();
-	
+	let has_meta = archive.by_name("config/meta.json").is_ok()
+		|| archive.by_name("config\\meta.json").is_ok();
+
 	if !has_meta {
-	    return Err("Zip file is missing config/meta.json!".to_string());
+		return Err(String::from("Zip file is missing config/meta.json!"));
 	}
 
 	// extract zip into slime2

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -231,17 +231,12 @@ pub async fn install_custom_widget(
 	};
 
 	// check if zip contains meta.json
-	if let Err(_) =
-		file::extract_file_from_zip(source_path, "config\\meta.json")
-	{
-		if let Err(error) =
-			file::extract_file_from_zip(source_path, "config/meta.json")
-		{
-			return Err(format!(
-				"Zip file is missing config/meta.json! {}",
-				error
-			));
-		}
+	let has_meta =
+	    archive.by_name("config/meta.json").is_ok()
+	    || archive.by_name("config\\meta.json").is_ok();
+	
+	if !has_meta {
+	    return Err("Zip file is missing config/meta.json!".to_string());
 	}
 
 	// extract zip into slime2

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -231,8 +231,8 @@ pub async fn install_custom_widget(
 	};
 
 	// check if zip contains meta.json
-	let has_meta = archive.by_name("config/meta.json").is_ok()
-		|| archive.by_name("config\\meta.json").is_ok();
+	let has_meta = archive.by_name("config\\meta.json").is_ok()
+		|| archive.by_name("config/meta.json").is_ok();
 
 	if !has_meta {
 		return Err(String::from("Zip file is missing config/meta.json!"));
@@ -501,18 +501,27 @@ pub async fn save_temp_widget_core_icon(
 pub async fn extract_widget_details(zip_path: &str) -> Result<String, String> {
 	let source_path = Path::new(zip_path);
 
-	// if zip was created in windows, uses \ for separator, otherwise / in unix
-	match file::extract_file_from_zip(source_path, "config\\meta.json") {
-		Ok(file_contents) => return Ok(file_contents),
-		Err(_) => {
-			match file::extract_file_from_zip(source_path, "config/meta.json") {
-				Ok(file_contents) => return Ok(file_contents),
-				Err(error) => {
-					return Err(format!("File meta.json not found! {}", error));
-				}
-			};
+	let mut archive = match file::unzip(source_path) {
+		Ok(archive) => archive,
+		Err(error) => {
+			return Err(format!("Failed to open zip: {}", error));
 		}
 	};
+
+	let mut zip_file_meta =
+		if let Ok(file) = archive.by_name("config\\meta.json") {
+			file
+		} else if let Ok(file) = archive.by_name("config/meta.json") {
+			file
+		} else {
+			return Err(String::from("File meta.json not found!"));
+		};
+
+	let mut file_contents = String::new();
+	if let Err(error) = zip_file_meta.read_to_string(&mut file_contents) {
+		return Err(format!("Error reading meta.json: {}", error));
+	}
+	Ok(file_contents)
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]

--- a/src-tauri/src/file.rs
+++ b/src-tauri/src/file.rs
@@ -3,7 +3,7 @@ use serde_json::Number;
 use std::{
 	collections::HashMap,
 	fs::{self, File},
-	io::{self, Read},
+	io,
 	path::{Path, PathBuf},
 	time::{SystemTime, UNIX_EPOCH},
 };
@@ -313,22 +313,6 @@ pub fn generate_widget_config(
 	)?;
 
 	Ok(())
-}
-
-pub fn extract_file_from_zip(
-	source_path: &Path,
-	file_name: &str,
-) -> io::Result<String> {
-	let mut archive = unzip(source_path)?;
-	let mut file_contents = String::new();
-	let Ok(mut file) = archive.by_name(file_name) else {
-		return Err(io::Error::new(
-			io::ErrorKind::NotFound,
-			format!("{} not found in ZIP!", file_name),
-		));
-	};
-	file.read_to_string(&mut file_contents)?;
-	return Ok(file_contents);
 }
 
 // get path to overlay_server folder (built by src-overlay)


### PR DESCRIPTION
Related to https://github.com/zaytri/slime2-desktop/pull/7 and https://github.com/zip-rs/zip2/issues/853

Tested and it works! No longer need to duplicate archive creation for checking both separator types.